### PR TITLE
Updated `nix-shell` dependencies and fixed `\today` latex-command on nix-systems

### DIFF
--- a/LaTeX/.gitignore
+++ b/LaTeX/.gitignore
@@ -1,4 +1,5 @@
 temp/
+output/
 *.aux
 *.log
 *.out

--- a/LaTeX/shell.nix
+++ b/LaTeX/shell.nix
@@ -3,8 +3,15 @@
 pkgs.mkShell {
   packages = [
     (pkgs.python3.withPackages(p: with p; [
-      pypandoc
+      # If python packages need to be included:
+      # p.pkgs-name
     ]))
     pkgs.pandoc
+    pkgs.which
+    pkgs.texliveFull
   ];
+  # This fixes the \today command in LaTeX to the current date
+  shellHook = ''
+    export SOURCE_DATE_EPOCH=$(${pkgs.coreutils}/bin/date +%s)
+  '';
 }


### PR DESCRIPTION
Removed unnecessary  `nix-shell` dependency and added some missing. I also fixed the `\today` latex-command on nix-systems.